### PR TITLE
Fix missing variable declaration

### DIFF
--- a/owp-export.el
+++ b/owp-export.el
@@ -104,7 +104,7 @@ content of the buffer will be converted into html."
                               :thumb ,(owp/read-org-option "THUMBNAIL")))
          assets-dir post-content
          asset-path asset-abs-path pub-abs-path converted-path
-         component-table tags category cat-config)
+         component-table tags authors category cat-config)
     (setq tags (owp/read-org-option "TAGS"))
     (when tags
       (plist-put


### PR DESCRIPTION
I got following byte-compile warnings

```
In owp/get-org-file-options:
owp-export.el:114:11:Warning: assignment to free variable `authors'
owp-export.el:117:61:Warning: reference to free variable `authors'
```
