### PR TITLE
Fix for cl-lib.el and cl.el

### DIFF
--- a/org-webpage.el
+++ b/org-webpage.el
@@ -130,8 +130,8 @@
           (sort (owp/directory-files-recursively repo-dir nil "\\.org$")
                 #'(lambda (a b)
                     (time-less-p
-                     (sixth (file-attributes b))
-                     (sixth (file-attributes a))))))
+                     (cl-sixth (file-attributes b))
+                     (cl-sixth (file-attributes a))))))
          (length-repo-files (length repo-files))
          (update-top-n
           (cond ((and partial-update (numberp update-top-n)) update-top-n)

--- a/owp-export.el
+++ b/owp-export.el
@@ -35,6 +35,7 @@
 (require 'owp-vars)
 (require 'owp-config)
 (require 'owp-template)
+(require 'cl-lib)
 
 
 (defun owp/publish-changes (files-list change-plist pub-root-dir)
@@ -207,7 +208,7 @@ can contain following parameters:
         (encoded-title (owp/encode-string-to-url title)))
     (format-spec uri-template `((?y . ,(car date-list))
                                 (?m . ,(cadr date-list))
-                                (?d . ,(caddr date-list))
+                                (?d . ,(cl-caddr date-list))
                                 (?t . ,encoded-title)))))
 
 

--- a/owp-util.el
+++ b/owp-util.el
@@ -30,27 +30,28 @@
 (require 'ht)
 (require 'owp-vars)
 (require 'owp-config)
+(require 'cl-lib)
 
 (defun owp/directory-files-recursively (directory &optional type regexp)
   "recursively list all the files in a directory"
   (let* ((directory (or directory default-directory))
          (regexp  (if regexp regexp ".*"))
-         (predfunc (case type
+         (predfunc (cl-case type
                      (dir 'file-directory-p)
                      (file 'file-regular-p)
                      (otherwise 'identity)))
-         (files (delete-if
+         (files (cl-delete-if
                  (lambda (s)
                    (string-match (rx bol (repeat 1 2 ".") eol)
                                  (file-name-nondirectory s)))
                  (directory-files directory t nil t))))
-    (loop for file in files
-          when (and (funcall predfunc file)
-                    (string-match regexp (file-name-nondirectory file)))
-          collect file into ret
-          when (file-directory-p file)
-          nconc (eh-directory-files-recursively file type regexp) into ret
-          finally return ret)))
+    (cl-loop for file in files
+             when (and (funcall predfunc file)
+                       (string-match regexp (file-name-nondirectory file)))
+             collect file into ret
+             when (file-directory-p file)
+             nconc (eh-directory-files-recursively file type regexp) into ret
+             finally return ret)))
 
 (defun owp/compare-standard-date (date1 date2)
   "Compare two standard ISO 8601 format dates, format is as below:

--- a/owp-web-server.el
+++ b/owp-web-server.el
@@ -24,6 +24,10 @@
 ;; owp-web-server.el is a web server used to test org-webpage.
 
 ;;; Code:
+
+(eval-when-compile
+  (require 'cl))
+
 (require 'url-util)
 (require 'browse-url)
 (require 'web-server)


### PR DESCRIPTION
- use cl-lib functions and macros instead cl.el functions and macros
- load cl.el at compile time for using `lexical-let`.
