### PR TITLE
Default index

### DIFF
--- a/owp-export.el
+++ b/owp-export.el
@@ -455,7 +455,7 @@ publication directory."
                   (mapcar
                    #'(lambda (cell)
                        (ht ("id" (setq id (+ id 1)))
-                           ("category" (car cell))
+                           ("category" (capitalize (car cell)))
                            ("posts" (mapcar
                                      #'(lambda (plist)
                                          (ht ("post-uri"

--- a/owp-export.el
+++ b/owp-export.el
@@ -469,7 +469,10 @@ publication directory."
                                              ("post-thumb"
                                               (or (plist-get plist :thumb) ""))))
                                      (cdr cell)))))
-                   sort-alist)))))
+                   (cl-remove-if
+                    #'(lambda (cell)
+                        (string= (car cell) "about"))
+                    sort-alist))))))
            ("footer"
             (owp/render-footer
              (ht ("show-meta" nil)


### PR DESCRIPTION
The default index page did not capitalize its category headings and it listed "about" as one category and linked to the "about" page. Both problems are fixed here as separate commits.
