### PR TITLE
allow to modify template context from configurations

### DIFF
--- a/owp-config.el
+++ b/owp-config.el
@@ -136,6 +136,24 @@ multi path."
         :sort-by :date
         :category-index t)))
 
+(defun owp/get-injected-template (key)
+  "The function, which can return template from injector for a
+given KEY.
+
+Example of key is :footer-template."
+  (when-let ((func (owp/get-config-option :injector)))
+    (ht<-alist
+     (ht-map
+      (lambda (key val)
+        (cons
+         (cl-typecase key
+           (keyword (string-remove-prefix ":" (symbol-name key)))
+           (symbol (symbol-name key))
+           (t key))
+         val))
+      (ht<-plist
+       (funcall func key))))))
+
 (provide 'owp-config)
 
 ;;; owp-config.el ends here

--- a/owp-template.el
+++ b/owp-template.el
@@ -116,8 +116,7 @@ a hash table accordint to current buffer."
                           user-full-name "Unknown Author"))
             ("description" (owp/read-org-option "DESCRIPTION"))
             ("keywords" (owp/read-org-option "KEYWORDS"))))
-    (or (owp/get-config-option :header-context)
-        (make-hash-table)))))
+    (owp/get-injected-template :header-template))))
 
 (defun owp/render-navigation-bar (&optional param-table org-file)
   "Render the navigation bar on each page. it will be read firstly from
@@ -180,8 +179,7 @@ render from a default hash table."
                                    site-domain)
                                   (match-string 1 site-domain)
                                 site-domain))))
-       (or (owp/get-config-option :navigation-bar-context)
-           (make-hash-table)))))))
+       (owp/get-injected-template :navigation-bar-template))))))
 
 (defun owp/render-content (&optional template param-table org-file)
   "Render the content on each page. TEMPLATE is the template name for rendering,
@@ -204,8 +202,7 @@ similar to `owp/render-header'."
                          (let ((org-export-function (owp/get-config-option :org-export-function)))
                            (when (functionp org-export-function)
                              (funcall org-export-function)))))))
-    (or (owp/get-config-option :content-context)
-        (make-hash-table)))))
+    (owp/get-injected-template :content-template))))
 
 (defun owp/default-org-export ()
   "A function with can export org file to html."
@@ -279,8 +276,7 @@ similar to `owp/render-header'."
               ("email" (owp/confound-email-address (or (owp/read-org-option "EMAIL")
                                                        user-mail-address
                                                        "Unknown Email"))))))
-    (or (owp/get-config-option :footer-context)
-        (make-hash-table)))))
+    (owp/get-injected-template :footer-template))))
 
 (provide 'owp-template)
 

--- a/owp-vars.el
+++ b/owp-vars.el
@@ -396,6 +396,17 @@ from `:el2org-index-source'.
 1. Type: list
 2. Example: (\"tag1\" \"tag2\" \"tag3\")
 
+  `:injector'
+
+Function used to retrieve additional context for a given
+moustache template. Available templates are `:header-template',
+`:navigation-bar-template', `:content-template' and
+`:footer-template'.
+1. Example: (lambda (template)
+                    (cl-case template
+                      (:footer-template
+                       (list :key1 val1
+                             :key2 val2))))
 
 You can see fallback value of above option in `owp/config-fallback'
 

--- a/owp-vars.el
+++ b/owp-vars.el
@@ -396,17 +396,42 @@ from `:el2org-index-source'.
 1. Type: list
 2. Example: (\"tag1\" \"tag2\" \"tag3\")
 
-  `:injector'
 
-Function used to retrieve additional context for a given
-moustache template. Available templates are `:header-template',
-`:navigation-bar-template', `:content-template' and
-`:footer-template'.
-1. Example: (lambda (template)
-                    (cl-case template
-                      (:footer-template
-                       (list :key1 val1
-                             :key2 val2))))
+  `:template-context'
+
+Global plist containing context for site templates.
+1. Type: plist
+2. Example: (\"key1\" \"value1\"
+             \"key2\" \"value2\")
+
+
+  `:header-template-context'
+
+Header plist containing context for site templates. Overrides
+values from `:template-contex'. Checkout `:template-context' for
+examples.
+
+
+  `:navigation-bar-template-context'
+
+Navigation bar plist containing context for site templates.
+Overrides values from `:template-contex'. Checkout
+`:template-context' for examples.
+
+
+  `:content-template-context'
+
+Content plist containing context for site templates. Overrides
+values from `:template-contex'. Checkout `:template-context' for
+examples.
+
+
+  `:footer-template-context'
+
+Footer plist containing context for site templates. Overrides
+values from `:template-contex'. Checkout `:template-context' for
+examples.
+
 
 You can see fallback value of above option in `owp/config-fallback'
 


### PR DESCRIPTION
I couldn't find a way to pass custom context to moustache render function. Let me know if I missed it.

In general I find it useful when working on your own theme. 

---

```
;; configuration
(owp/add-project-config
 `("tumashu.github.com"
   :repository-directory "~/project/emacs-packages/tumashu.github.com"
   :remote (git "https://github.com/tumashu/tumashu.github.com.git" "master")
   ;; you can use `rclone` with `:remote (rclone "remote-name" "/remote/path/location")` instead.
   :site-domain "http://tumashu.github.com/"
   :site-main-title "Tumashu 的个人小站"
   :site-sub-title "(九天十地，太上忘情！！！)"
   :theme (worg)
   :source-browse-url ("Github" "https://github.com/tumashu/tumashu.github.com")
   :personal-avatar "/media/img/horse.jpg"
   :personal-duoshuo-shortname "tumashu-website"
   :web-server-port 7654
   :footer-context ,(ht ("emacs-version" emacs-version))
))
```

```
;; template
Built with Emacs {{emacs-version}}
```